### PR TITLE
chore: remove redundant start command from apply_schema

### DIFF
--- a/scripts/start_apply_schema.sh
+++ b/scripts/start_apply_schema.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
 
-# Start Defra with rootdir
-~/go/bin/defradb start --rootdir ~/Developer/shinzo/version1/.defra & 
-
 # Apply the new schema
 ~/go/bin/defradb client schema add -f schema/schema.graphql


### PR DESCRIPTION
## Why?
- apply_schema does not need a start defra command and assumes you have already started defra
- apply_schema only should contain the command to set defra schema objects.